### PR TITLE
Add FastAPI example with frontend fetch

### DIFF
--- a/fastapi_example/README.md
+++ b/fastapi_example/README.md
@@ -1,0 +1,18 @@
+# FastAPI Frontend ↔ Backend Example
+
+This example demonstrates how to connect a simple frontend to a FastAPI backend.
+
+## Backend
+
+Run the FastAPI server:
+
+```bash
+pip install -r requirements.txt
+python backend/main.py
+```
+
+The server exposes `GET /api/message` which returns a JSON message.
+
+## Frontend
+
+Open `frontend/index.html` in a browser. It uses the Fetch API to request the message from the backend and displays the response on the page.

--- a/fastapi_example/backend/main.py
+++ b/fastapi_example/backend/main.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"]
+)
+
+@app.get("/api/message")
+async def get_message():
+    return {"message": "Hello from FastAPI"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/fastapi_example/frontend/index.html
+++ b/fastapi_example/frontend/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>FastAPI Fetch Example</title>
+</head>
+<body>
+    <h1>Message from Backend:</h1>
+    <pre id="response"></pre>
+    <script>
+        async function loadMessage() {
+            const res = await fetch('http://localhost:8000/api/message');
+            const data = await res.json();
+            document.getElementById('response').textContent = data.message;
+        }
+        loadMessage();
+    </script>
+</body>
+</html>

--- a/fastapi_example/requirements.txt
+++ b/fastapi_example/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add `fastapi_example` with a simple FastAPI backend and frontend code
- show how to fetch a message from FastAPI using JavaScript

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6850c1f7fd008331af3f039f02ac008d